### PR TITLE
Decode unicode

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,12 +116,19 @@ class ShopifyAKImporter:
             # Write CSV row
             csv_writer.writerow([
                 donation_import_id, email, donation_date,
-                donation_amount, first_name.encode('utf-8'), last_name.encode('utf-8'),
-                address1.encode('utf-8'), address2, city.encode('utf-8'),
+                donation_amount,
+                first_name.encode('utf-8').decode('utf-8', 'ignore'),
+                last_name.encode('utf-8').decode('utf-8', 'ignore'),
+                address1.encode('utf-8').decode('utf-8', 'ignore'),
+                address2,
+                city.encode('utf-8').decode('utf-8', 'ignore'),
                 postal, state, country,
-                phone, user_occupation.encode('utf-8'), user_employer.encode('utf-8'),
+                phone,
+                user_occupation.encode('utf-8').decode('utf-8', 'ignore'),
+                user_employer.encode('utf-8').decode('utf-8', 'ignore'),
                 self.settings.AK_SOURCE, self.settings.AK_PAYMENT_ACCOUNT,
-                user_occupation.encode('utf-8'), user_employer.encode('utf-8')
+                user_occupation.encode('utf-8').decode('utf-8', 'ignore'),
+                user_employer.encode('utf-8').decode('utf-8', 'ignore')
             ])
 
         return output_file


### PR DESCRIPTION
Values have been saved like `b'Jane'`, with the `b''` actually saved to ActionKit. I believe this was introduced by https://github.com/MoveOnOrg/shopify-ak-import/pull/3. This fixes the `b''` problem, but I don't have an example of the problem the original PR was solving, and only a vague memory of what that problem was. I think Unicode characters were causing the ActionKit imports to throw errors.

So I _think_ what this does now is remove anything that would throw an error, but I unfortunately don't have an example to test that with.