### PR TITLE
Remove utf-8 encoding

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,19 +116,12 @@ class ShopifyAKImporter:
             # Write CSV row
             csv_writer.writerow([
                 donation_import_id, email, donation_date,
-                donation_amount,
-                first_name.encode('utf-8').decode('utf-8', 'ignore'),
-                last_name.encode('utf-8').decode('utf-8', 'ignore'),
-                address1.encode('utf-8').decode('utf-8', 'ignore'),
-                address2,
-                city.encode('utf-8').decode('utf-8', 'ignore'),
+                donation_amount, first_name, last_name,
+                address1, address2, city,
                 postal, state, country,
-                phone,
-                user_occupation.encode('utf-8').decode('utf-8', 'ignore'),
-                user_employer.encode('utf-8').decode('utf-8', 'ignore'),
+                phone, user_occupation, user_employer,
                 self.settings.AK_SOURCE, self.settings.AK_PAYMENT_ACCOUNT,
-                user_occupation.encode('utf-8').decode('utf-8', 'ignore'),
-                user_employer.encode('utf-8').decode('utf-8', 'ignore')
+                user_occupation, user_employer
             ])
 
         return output_file

--- a/main.py
+++ b/main.py
@@ -116,12 +116,19 @@ class ShopifyAKImporter:
             # Write CSV row
             csv_writer.writerow([
                 donation_import_id, email, donation_date,
-                donation_amount, first_name.encode('utf-8'), last_name.encode('utf-8'),
-                address1.encode('utf-8'), address2, city.encode('utf-8'),
+                donation_amount,
+                first_name.encode('utf-8').decode('utf-8', 'ignore'),
+                last_name.encode('utf-8').decode('utf-8', 'ignore'),
+                address1.encode('utf-8').decode('utf-8', 'ignore'),
+                address2,
+                city.encode('utf-8').decode('utf-8', 'ignore'),
                 postal, state, country,
-                phone, user_occupation.encode('utf-8'), user_employer.encode('utf-8'),
+                phone,
+                user_occupation.encode('utf-8').decode('utf-8', 'ignore'),
+                user_employer.encode('utf-8').decode('utf-8', 'ignore'),
                 self.settings.AK_SOURCE, self.settings.AK_PAYMENT_ACCOUNT,
-                user_occupation.encode('utf-8'), user_employer.encode('utf-8')
+                user_occupation.encode('utf-8').decode('utf-8', 'ignore'),
+                user_employer.encode('utf-8').decode('utf-8', 'ignore')
             ])
 
         return output_file


### PR DESCRIPTION
This undoes #3, which introduced a new bug (saving vaues with `b''`) while fixing a problem I can no longer identify nor replicate using 2 weeks of data before #3 was added. It's likely whatever problem  #3 fixed will come back at some point, and then we can make a better version of #3 that doesn't have the `b''` problem and has tests.